### PR TITLE
Update install docs to install ko using Scoop

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -29,6 +29,12 @@ $ chmod +x ./ko
 brew install ko
 ```
 
+### Install on Windows using [Scoop](https://scoop.sh)
+
+```plaintext
+scoop install ko
+```
+
 ### Install on [Alpine Linux](https://www.alpinelinux.org)
 
 Installation on Alpine requires using the [`testing` repository](https://wiki.alpinelinux.org/wiki/Enable_Community_Repository#Using_testing_repositories)


### PR DESCRIPTION
Hello, I recently created a pr in the main bucket of [Scoop](https://github.com/ScoopInstaller/Main/pull/5035), to add Ko as a package. This allows Windows users to install Ko using the `scoop install ko` command on Windows and makes using this great tool a lot easier. :-).

As soon as the pr in the Scoop repo is merged, I'd like to update the docs how to install Ko on Windows.

